### PR TITLE
Change from `_initialise_params` to `init_params` convention.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIRES = [
     "jaxutils>=0.0.8",
     "jaxtyping>=0.0.2",
     "jaxlinop>=0.0.3",
-    "depreciation"
+    "deprecation",
 ]
 
 EXTRAS = {

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,13 @@ if "BUILD_JAXKERN_NIGHTLY" in os.environ:
 REQUIRES = [
     "jax>=0.4.1",
     "jaxlib>=0.4.1",
-    "jaxutils",
+    "jaxutils>=0.0.8",
     "jaxtyping>=0.0.2",
     "jaxlinop>=0.0.3",
 ]
 
 EXTRAS = {
     "dev": [
-        "gpjax",
         "black",
         "isort",
         "pylint",

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ REQUIRES = [
     "jaxutils>=0.0.8",
     "jaxtyping>=0.0.2",
     "jaxlinop>=0.0.3",
+    "depreciation"
 ]
 
 EXTRAS = {

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import networkx as nx
 import pytest
-from gpjax.parameters import initialise
+from jaxutils.parameters import initialise
 from jax.config import config
 from jax.random import KeyArray
 from jaxlinop import LinearOperator, identity


### PR DESCRIPTION
This is in light of JaxGaussianProcesses/GPJax#172

Depreciates `._initialise_params(key)` to `.init_params(key)`.