### PR TITLE
Now splitting key within init_params in combination kernels

### DIFF
--- a/jaxkern/base.py
+++ b/jaxkern/base.py
@@ -19,6 +19,7 @@ from typing import Callable, Dict, List, Optional, Sequence
 import deprecation
 import jax.numpy as jnp
 import jax.random
+import jax
 from jax.random import KeyArray
 from jaxtyping import Array, Float
 from jaxutils import PyTree

--- a/jaxkern/base.py
+++ b/jaxkern/base.py
@@ -18,6 +18,7 @@ from typing import Callable, Dict, List, Optional, Sequence
 
 import deprecation
 import jax.numpy as jnp
+import jax.random
 from jax.random import KeyArray
 from jaxtyping import Array, Float
 from jaxutils import PyTree
@@ -176,7 +177,9 @@ class CombinationKernel(AbstractKernel):
 
     def init_params(self, key: KeyArray) -> Dict:
         """A template dictionary of the kernel's parameter set."""
-        return [kernel.init_params(key) for kernel in self.kernel_set]
+        num_kernels = len(self.kernel_set)
+        key_per_kernel = jax.random.split(key=key, num=num_kernels)
+        return [kernel.init_params(key_) for key_, kernel in zip(key_per_kernel, self.kernel_set)]
 
     def __call__(
         self,


### PR DESCRIPTION
The key in init_params for combination kernels are currently reused within each internal kernel. As such, if one uses multiple of the same kernel within (e.g. to use a sum of kernels with multiple lengthscales), they will be initialised to be identical. This is problematic as the symmetry between them forces them to stay the same using gradient-based local optimization. 

This splits the key so that each kernel will be initialised to its own state (if using random initialisation). 