### PR TITLE
Added symmetry-breaking init in rbf

### DIFF
--- a/jaxkern/stationary/rbf.py
+++ b/jaxkern/stationary/rbf.py
@@ -64,8 +64,10 @@ class RBF(AbstractKernel):
         return K.squeeze()
 
     def init_params(self, key: KeyArray) -> Dict:
+        eps = 1e-3
+        random_jitter = jax.random.uniform(key, shape=[self.ndims], minval=-eps, maxval=eps)
         params = {
-            "lengthscale": jnp.array([1.0] * self.ndims),
+            "lengthscale": jnp.array([1.0] * self.ndims) + random_jitter,
             "variance": jnp.array([1.0]),
         }
         return jax.tree_util.tree_map(lambda x: jnp.atleast_1d(x), params)


### PR DESCRIPTION
The init_params method currently initializes (for example) the rbf kernel deterministically. As such, when using a combination kernel of the same kernel types, the kernels are initialized to be identical. This is problematic as the symmetry between them forces them to stay the same using gradient-based local optimization, preventing e.g.  a sum of multiple lengthscales to be learnt (if not breaking the symmetries in some other way). 

This adds a random jitter to the RBF kernels lengthscales to break the symmetry. To resolve the same issue for the other kernels, they would need something similar. 

The following PR makes the change to pass a unique key to each kernel within the combination kernel:
https://github.com/JaxGaussianProcesses/JaxKern/pull/41