### PR TITLE
Fix typing and expose compute class

### DIFF
--- a/jaxkern/computations/base.py
+++ b/jaxkern/computations/base.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 import abc
-from typing import Callable, Dict
+from typing import Callable
 
 from jax import vmap
 from jaxlinop import (
@@ -23,7 +23,7 @@ from jaxlinop import (
     LinearOperator,
 )
 from jaxtyping import Array, Float
-from jaxutils import PyTree
+from jaxutils import PyTree, Parameters
 
 
 class AbstractKernelComputation(PyTree):
@@ -32,7 +32,7 @@ class AbstractKernelComputation(PyTree):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         self._kernel_fn = kernel_fn
@@ -40,26 +40,28 @@ class AbstractKernelComputation(PyTree):
     @property
     def kernel_fn(
         self,
-    ) -> Callable[[Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array]:
+    ) -> Callable[[Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array]:
         return self._kernel_fn
 
     @kernel_fn.setter
     def kernel_fn(
         self,
-        kernel_fn: Callable[[Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array],
+        kernel_fn: Callable[
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+        ],
     ) -> None:
         self._kernel_fn = kernel_fn
 
     def gram(
         self,
-        params: Dict,
+        params: Parameters,
         inputs: Float[Array, "N D"],
     ) -> LinearOperator:
         """Compute Gram covariance operator of the kernel function.
 
         Args:
             kernel (AbstractKernel): The kernel function to be evaluated.
-            params (Dict): The parameters of the kernel function.
+            params (Parameters): The parameters of the kernel function.
             inputs (Float[Array, "N N"]): The inputs to the kernel function.
 
         Returns:
@@ -73,7 +75,7 @@ class AbstractKernelComputation(PyTree):
     @abc.abstractmethod
     def cross_covariance(
         self,
-        params: Dict,
+        params: Parameters,
         x: Float[Array, "N D"],
         y: Float[Array, "M D"],
     ) -> Float[Array, "N M"]:
@@ -83,7 +85,7 @@ class AbstractKernelComputation(PyTree):
         Args:
             kernel (AbstractKernel): The kernel for which the cross-covariance
                 matrix should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             x (Float[Array,"N D"]): The first input matrix.
             y (Float[Array,"M D"]): The second input matrix.
 
@@ -94,7 +96,7 @@ class AbstractKernelComputation(PyTree):
 
     def diagonal(
         self,
-        params: Dict,
+        params: Parameters,
         inputs: Float[Array, "N D"],
     ) -> DiagonalLinearOperator:
         """For a given kernel, compute the elementwise diagonal of the
@@ -103,7 +105,7 @@ class AbstractKernelComputation(PyTree):
         Args:
             kernel (AbstractKernel): The kernel for which the variance
                 vector should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             inputs (Float[Array, "N D"]): The input matrix.
 
         Returns:

--- a/jaxkern/computations/basis_functions.py
+++ b/jaxkern/computations/basis_functions.py
@@ -1,9 +1,10 @@
-from typing import Callable, Dict
+from typing import Callable
 
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 from .base import AbstractKernelComputation
 from jaxlinop import DenseLinearOperator
+from jaxutils import Parameters
 
 
 class BasisFunctionComputation(AbstractKernelComputation):
@@ -12,7 +13,7 @@ class BasisFunctionComputation(AbstractKernelComputation):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         """Initialise the computation engine for a basis function approximation to a kernel.
@@ -33,11 +34,11 @@ class BasisFunctionComputation(AbstractKernelComputation):
         self._num_basis_fns = float(num_basis_fns)
 
     def cross_covariance(
-        self, params: Dict, x: Float[Array, "N D"], y: Float[Array, "M D"]
+        self, params: Parameters, x: Float[Array, "N D"], y: Float[Array, "M D"]
     ) -> Float[Array, "N M"]:
         """For a pair of inputs, compute the cross covariance matrix between the inputs.
         Args:
-            params (Dict): A dictionary of parameters for which the cross-covariance matrix should be constructed with.
+            params (Parameters): A dictionary of parameters for which the cross-covariance matrix should be constructed with.
             x: A N x D array of inputs.
             y: A M x D array of inputs.
 
@@ -53,11 +54,13 @@ class BasisFunctionComputation(AbstractKernelComputation):
         z1 /= self.num_basis_fns
         return params["variance"] * jnp.matmul(z1, z2.T)
 
-    def gram(self, params: Dict, inputs: Float[Array, "N D"]) -> DenseLinearOperator:
+    def gram(
+        self, params: Parameters, inputs: Float[Array, "N D"]
+    ) -> DenseLinearOperator:
         """For the Gram matrix, we can save computations by computing only one matrix multiplication between the inputs and the scaled frequencies.
 
         Args:
-            params (Dict): A dictionary of parameters for which the Gram matrix should be constructed with.
+            params (Parameters): A dictionary of parameters for which the Gram matrix should be constructed with.
             inputs: A N x D array of inputs.
 
         Returns:

--- a/jaxkern/computations/constant_diagonal.py
+++ b/jaxkern/computations/constant_diagonal.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Callable, Dict
+from typing import Callable
 import jax.numpy as jnp
 
 from jax import vmap
@@ -23,20 +23,21 @@ from jaxlinop import (
 )
 from jaxtyping import Array, Float
 from .base import AbstractKernelComputation
+from jaxutils import Parameters
 
 
 class ConstantDiagonalKernelComputation(AbstractKernelComputation):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         super().__init__(kernel_fn)
 
     def gram(
         self,
-        params: Dict,
+        params: Parameters,
         inputs: Float[Array, "N D"],
     ) -> ConstantDiagonalLinearOperator:
         """For a kernel with diagonal structure, compute the NxN gram matrix on
@@ -45,7 +46,7 @@ class ConstantDiagonalKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the Gram matrix
                 should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             inputs (Float[Array, "N D"]): The input matrix.
 
         Returns:
@@ -59,7 +60,7 @@ class ConstantDiagonalKernelComputation(AbstractKernelComputation):
 
     def diagonal(
         self,
-        params: Dict,
+        params: Parameters,
         inputs: Float[Array, "N D"],
     ) -> DiagonalLinearOperator:
         """For a given kernel, compute the elementwise diagonal of the
@@ -68,7 +69,7 @@ class ConstantDiagonalKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the variance
                 vector should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             inputs (Float[Array, "N D"]): The input matrix.
 
         Returns:
@@ -80,7 +81,7 @@ class ConstantDiagonalKernelComputation(AbstractKernelComputation):
         return DiagonalLinearOperator(diag=diag)
 
     def cross_covariance(
-        self, params: Dict, x: Float[Array, "N D"], y: Float[Array, "M D"]
+        self, params: Parameters, x: Float[Array, "N D"], y: Float[Array, "M D"]
     ) -> Float[Array, "N M"]:
         """For a given kernel, compute the NxM covariance matrix on a pair of input
         matrices of shape NxD and MxD.
@@ -88,7 +89,7 @@ class ConstantDiagonalKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the Gram
                 matrix should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             x (Float[Array,"N D"]): The input matrix.
             y (Float[Array,"M D"]): The input matrix.
 

--- a/jaxkern/computations/dense.py
+++ b/jaxkern/computations/dense.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Callable, Dict
+from typing import Callable
 
 from jax import vmap
 from jaxtyping import Array, Float
 from .base import AbstractKernelComputation
+from jaxutils import Parameters
 
 
 class DenseKernelComputation(AbstractKernelComputation):
@@ -28,13 +29,13 @@ class DenseKernelComputation(AbstractKernelComputation):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         super().__init__(kernel_fn)
 
     def cross_covariance(
-        self, params: Dict, x: Float[Array, "N D"], y: Float[Array, "M D"]
+        self, params: Parameters, x: Float[Array, "N D"], y: Float[Array, "M D"]
     ) -> Float[Array, "N M"]:
         """For a given kernel, compute the NxM covariance matrix on a pair of input
         matrices of shape NxD and MxD.
@@ -42,7 +43,7 @@ class DenseKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the Gram
                 matrix should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             x (Float[Array,"N D"]): The input matrix.
             y (Float[Array,"M D"]): The input matrix.
 

--- a/jaxkern/computations/diagonal.py
+++ b/jaxkern/computations/diagonal.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Callable, Dict
+from typing import Callable
 
 from jax import vmap
 from jaxlinop import (
@@ -21,20 +21,21 @@ from jaxlinop import (
 )
 from jaxtyping import Array, Float
 from .base import AbstractKernelComputation
+from jaxutils import Parameters
 
 
 class DiagonalKernelComputation(AbstractKernelComputation):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         super().__init__(kernel_fn)
 
     def gram(
         self,
-        params: Dict,
+        params: Parameters,
         inputs: Float[Array, "N D"],
     ) -> DiagonalLinearOperator:
         """For a kernel with diagonal structure, compute the NxN gram matrix on
@@ -43,7 +44,7 @@ class DiagonalKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the Gram matrix
                 should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             inputs (Float[Array, "N D"]): The input matrix.
 
         Returns:
@@ -55,7 +56,7 @@ class DiagonalKernelComputation(AbstractKernelComputation):
         return DiagonalLinearOperator(diag=diag)
 
     def cross_covariance(
-        self, params: Dict, x: Float[Array, "N D"], y: Float[Array, "M D"]
+        self, params: Parameters, x: Float[Array, "N D"], y: Float[Array, "M D"]
     ) -> Float[Array, "N M"]:
         """For a given kernel, compute the NxM covariance matrix on a pair of input
         matrices of shape NxD and MxD.
@@ -63,7 +64,7 @@ class DiagonalKernelComputation(AbstractKernelComputation):
         Args:
             kernel (AbstractKernel): The kernel for which the Gram
                 matrix should be computed for.
-            params (Dict): The kernel's parameter set.
+            params (Parameters): The kernel's parameter set.
             x (Float[Array,"N D"]): The input matrix.
             y (Float[Array,"M D"]): The input matrix.
 

--- a/jaxkern/computations/eigen.py
+++ b/jaxkern/computations/eigen.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Callable, Dict
+from typing import Callable, Tuple
 
 import jax.numpy as jnp
 from jaxtyping import Array, Float
+from jaxutils import Parameters
 from .base import AbstractKernelComputation
 
 
@@ -24,7 +25,7 @@ class EigenKernelComputation(AbstractKernelComputation):
     def __init__(
         self,
         kernel_fn: Callable[
-            [Dict, Float[Array, "1 D"], Float[Array, "1 D"]], Array
+            [Parameters, Float[Array, "1 D"], Float[Array, "1 D"]], Array
         ] = None,
     ) -> None:
         super().__init__(kernel_fn)
@@ -34,26 +35,54 @@ class EigenKernelComputation(AbstractKernelComputation):
 
     # Define an eigenvalue setter and getter property
     @property
-    def eigensystem(self) -> Float[Array, "N"]:
+    def eigensystem(self) -> Tuple[Float[Array, "N"], Float[Array, "N N"], int]:
+        """Returns the eigenvalues, eigenvectorsof the graph Laplacian and
+        number of vertices in the graph.
+
+        Returns:
+            Tuple[Float[Array], Float[Array], int]: The eigenvalues, eigenvectors,
+                and number of vertices in the graph.
+        """
         return self._eigenvalues, self._eigenvectors, self._num_verticies
 
     @eigensystem.setter
     def eigensystem(
         self, eigenvalues: Float[Array, "N"], eigenvectors: Float[Array, "N N"]
     ) -> None:
+        """Set the eigenvalues and eigenvectors of the graph Laplacian.
+
+        Args:
+            eigenvalues (Float[Array]): The eigenvalues of the graph Laplacian.
+            eigenvectors (Float[Array]): The eigenvectors of the graph Laplacian.
+        """
         self._eigenvalues = eigenvalues
         self._eigenvectors = eigenvectors
 
     @property
     def num_vertex(self) -> int:
+        """Returns the number of vertices in the graph.
+
+        Returns:
+            int: The number of vertices in the graph.
+        """
         return self._num_verticies
 
     @num_vertex.setter
     def num_vertex(self, num_vertex: int) -> None:
         self._num_verticies = num_vertex
 
-    def _compute_S(self, params):
-        evals, evecs = self.eigensystem
+    def _compute_S(self, params: Parameters) -> Float[Array, "N"]:
+        """Transform the eigenvalues of the graph Laplacian according to the
+        RBF kernel's SPDE form.
+
+        Args:
+            params (Parameters): The parameters used to transform the Laplacian.
+                This will contain a smoothness, lengthscale, and variance parameter
+
+        Returns:
+            Float[Array, "N"]: The transformed eigenvalues.
+        """
+        evals, _ = self.eigensystem
         S = jnp.power(
             evals
             + 2 * params["smoothness"] / params["lengthscale"] / params["lengthscale"],
@@ -64,8 +93,18 @@ class EigenKernelComputation(AbstractKernelComputation):
         return S
 
     def cross_covariance(
-        self, params: Dict, x: Float[Array, "N D"], y: Float[Array, "M D"]
+        self, params: Parameters, x: Float[Array, "N D"], y: Float[Array, "M D"]
     ) -> Float[Array, "N M"]:
+        """Compute the cross covariance matrix between two sets of points.
+
+        Args:
+            params (Parameters): The parameters used to compute the covariance matrix.
+            x (Float[Array, "N D"]): The first set of points.
+            y (Float[Array, "M D"]): The second set of points.
+
+        Returns:
+            Float[Array, "N M"]: The NxM cross covariance matrix.
+        """
         S = self._compute_S(params=params)
         matrix = self.kernel_fn(params, x, y, S=S)
         return matrix

--- a/jaxkern/non_euclidean/graph.py
+++ b/jaxkern/non_euclidean/graph.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
 from jaxtyping import Array, Float
 
 from jaxutils import Parameters, Softplus
-from ..computations import EigenKernelComputation
+from ..computations import EigenKernelComputation, AbstractKernelComputation
 from ..base import AbstractKernel
 from .utils import jax_gather_nd
 
@@ -29,25 +29,31 @@ from .utils import jax_gather_nd
 # Graph kernels
 ##########################################
 class GraphKernel(AbstractKernel):
-    """A Matérn graph kernel defined on the vertices of a graph. The key reference for this object is borovitskiy et. al., (2020)."""
+    """A Matérn graph kernel defined on the vertices of a graph. The key reference for
+    this object is borovitskiy et. al., (2020)."""
 
     def __init__(
         self,
         laplacian: Float[Array, "N N"],
+        compute_engine: AbstractKernelComputation = EigenKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Matérn Graph kernel",
     ) -> None:
         """Initialize a Matérn graph kernel.
 
         Args:
-            laplacian (Float[Array]): An N x N matrix representing the Laplacian matrix of a graph.
-            compute_engine (EigenKernelComputation, optional): The compute engine that should be used in the kernel to compute covariance matrices. Defaults to EigenKernelComputation.
-            active_dims (Optional[List[int]], optional): The dimensions of the input data for which the kernel should be evaluated on. Defaults to None.
+            laplacian (Float[Array]): An N x N matrix representing the Laplacian
+                matrix of a graph.
+            compute_engine (EigenKernelComputation, optional): The compute engine that
+                should be used in the kernel to compute covariance matrices.
+                Defaults to EigenKernelComputation.
+            active_dims (Optional[List[int]], optional): The dimensions of the input
+                data for which the kernel should be evaluated on. Defaults to None.
             stationary (Optional[bool], optional): _description_. Defaults to False.
             name (Optional[str], optional): _description_. Defaults to "Graph kernel".
         """
         super().__init__(
-            EigenKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )
@@ -60,7 +66,7 @@ class GraphKernel(AbstractKernel):
 
     def __call__(
         self,
-        params: Dict,
+        params: Parameters,
         x: Float[Array, "1 D"],
         y: Float[Array, "1 D"],
         **kwargs,
@@ -68,7 +74,7 @@ class GraphKernel(AbstractKernel):
         """Evaluate the graph kernel on a pair of vertices :math:`v_i, v_j`.
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): Index of the ith vertex.
             y (Float[Array, "1 D"]): Index of the jth vertex.
 

--- a/jaxkern/nonstationary/linear.py
+++ b/jaxkern/nonstationary/linear.py
@@ -23,6 +23,7 @@ from jaxutils import Parameters, Softplus
 
 from ..base import AbstractKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 
@@ -35,12 +36,12 @@ class Linear(AbstractKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
-        stationary: Optional[bool] = False,
         name: Optional[str] = "Linear",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )

--- a/jaxkern/nonstationary/polynomial.py
+++ b/jaxkern/nonstationary/polynomial.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
@@ -22,6 +22,7 @@ from jaxutils import Parameters, Softplus
 
 from ..base import AbstractKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 
@@ -32,11 +33,12 @@ class Polynomial(AbstractKernel):
     def __init__(
         self,
         degree: int = 1,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Polynomial",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )
@@ -45,7 +47,7 @@ class Polynomial(AbstractKernel):
         self._stationary = False
 
     def __call__(
-        self, params: Dict, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
+        self, params: Parameters, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
     ) -> Float[Array, "1"]:
         """Evaluate the kernel on a pair of inputs :math:`(x, y)` with shift parameter :math:`\\alpha` and variance :math:`\\sigma^2` through
 
@@ -53,7 +55,7 @@ class Polynomial(AbstractKernel):
             k(x, y) = \\Big( \\alpha + \\sigma^2 xy \\Big)^{d}
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call
 

--- a/jaxkern/stationary/matern12.py
+++ b/jaxkern/stationary/matern12.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
@@ -22,6 +22,7 @@ from jaxutils import Parameters, Softplus
 
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 from .utils import euclidean_distance, build_student_t_distribution
@@ -32,15 +33,16 @@ class Matern12(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Matérn 1/2 kernel",
     ) -> None:
-        super().__init__(DenseKernelComputation, active_dims, name)
+        super().__init__(compute_engine, active_dims, name)
         self._spectral_density = build_student_t_distribution(1.0)
 
     def __call__(
         self,
-        params: Dict,
+        params: Parameters,
         x: Float[Array, "1 D"],
         y: Float[Array, "1 D"],
     ) -> Float[Array, "1"]:
@@ -51,7 +53,7 @@ class Matern12(StationaryKernel):
             k(x, y) = \\sigma^2 \\exp \\Bigg( -\\frac{\\lvert x-y \\rvert}{2\\ell^2}  \\Bigg)
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call
         Returns:

--- a/jaxkern/stationary/matern32.py
+++ b/jaxkern/stationary/matern32.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
@@ -22,6 +22,7 @@ from jaxutils import Parameters, Softplus
 
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 from .utils import euclidean_distance, build_student_t_distribution
@@ -32,15 +33,16 @@ class Matern32(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Matern 3/2",
     ) -> None:
-        super().__init__(DenseKernelComputation, active_dims, name)
+        super().__init__(compute_engine, active_dims, name)
         self._spectral_density = build_student_t_distribution(nu=3)
 
     def __call__(
         self,
-        params: Dict,
+        params: Parameters,
         x: Float[Array, "1 D"],
         y: Float[Array, "1 D"],
     ) -> Float[Array, "1"]:
@@ -51,7 +53,7 @@ class Matern32(StationaryKernel):
             k(x, y) = \\sigma^2 \\exp \\Bigg(1+ \\frac{\\sqrt{3}\\lvert x-y \\rvert}{\\ell^2}  \\Bigg)\\exp\\Bigg(-\\frac{\\sqrt{3}\\lvert x-y\\rvert}{\\ell^2} \\Bigg)
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call.
 

--- a/jaxkern/stationary/matern52.py
+++ b/jaxkern/stationary/matern52.py
@@ -13,16 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
 from jaxtyping import Array, Float
 from jaxutils import Parameters, Softplus
 from ..base import StationaryKernel
-from ..computations import (
-    DenseKernelComputation,
-)
+from ..computations import DenseKernelComputation, AbstractKernelComputation
 from .utils import euclidean_distance, build_student_t_distribution
 
 
@@ -31,14 +29,15 @@ class Matern52(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Matern 5/2",
     ) -> None:
-        super().__init__(DenseKernelComputation, active_dims, name)
+        super().__init__(compute_engine, active_dims, name)
         self._spectral_density = build_student_t_distribution(nu=5)
 
     def __call__(
-        self, params: Dict, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
+        self, params: Parameters, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
     ) -> Float[Array, "1"]:
         """Evaluate the kernel on a pair of inputs :math:`(x, y)` with
         lengthscale parameter :math:`\\ell` and variance :math:`\\sigma^2`
@@ -47,7 +46,7 @@ class Matern52(StationaryKernel):
             k(x, y) = \\sigma^2 \\exp \\Bigg(1+ \\frac{\\sqrt{5}\\lvert x-y \\rvert}{\\ell^2} + \\frac{5\\lvert x - y \\rvert^2}{3\\ell^2} \\Bigg)\\exp\\Bigg(-\\frac{\\sqrt{5}\\lvert x-y\\rvert}{\\ell^2} \\Bigg)
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call.
 

--- a/jaxkern/stationary/periodic.py
+++ b/jaxkern/stationary/periodic.py
@@ -23,6 +23,7 @@ from jaxtyping import Array
 from jaxutils import Parameters, Softplus
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 
@@ -35,11 +36,12 @@ class Periodic(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Periodic",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )

--- a/jaxkern/stationary/powered_exponential.py
+++ b/jaxkern/stationary/powered_exponential.py
@@ -22,6 +22,7 @@ from jaxtyping import Array
 from jaxutils import Parameters, Softplus
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 from .utils import euclidean_distance
@@ -36,11 +37,12 @@ class PoweredExponential(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Powered exponential",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )

--- a/jaxkern/stationary/rational_quadratic.py
+++ b/jaxkern/stationary/rational_quadratic.py
@@ -22,6 +22,7 @@ from jaxtyping import Array
 from jaxutils import Parameters, Softplus
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 from .utils import squared_distance
@@ -30,11 +31,12 @@ from .utils import squared_distance
 class RationalQuadratic(StationaryKernel):
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Rational Quadratic",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )

--- a/jaxkern/stationary/rbf.py
+++ b/jaxkern/stationary/rbf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import jax.numpy as jnp
 from jax.random import KeyArray
@@ -22,6 +22,7 @@ from jaxutils import Parameters, Softplus
 
 from ..base import StationaryKernel
 from ..computations import (
+    AbstractKernelComputation,
     DenseKernelComputation,
 )
 from .utils import squared_distance
@@ -33,18 +34,19 @@ class RBF(StationaryKernel):
 
     def __init__(
         self,
+        compute_engine: AbstractKernelComputation = DenseKernelComputation,
         active_dims: Optional[List[int]] = None,
         name: Optional[str] = "Radial basis function kernel",
     ) -> None:
         super().__init__(
-            DenseKernelComputation,
+            compute_engine,
             active_dims,
             name=name,
         )
         self._spectral_density = dx.Normal(loc=0.0, scale=1.0)
 
     def __call__(
-        self, params: Dict, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
+        self, params: Parameters, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
     ) -> Float[Array, "1"]:
         """Evaluate the kernel on a pair of inputs :math:`(x, y)` with
         lengthscale parameter :math:`\\ell` and variance :math:`\\sigma^2`
@@ -53,7 +55,7 @@ class RBF(StationaryKernel):
             k(x, y) = \\sigma^2 \\exp \\Bigg( \\frac{\\lVert x - y \\rVert^2_2}{2 \\ell^2} \\Bigg)
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call.
 

--- a/jaxkern/stationary/white.py
+++ b/jaxkern/stationary/white.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, Optional, List
+from typing import Optional, List
 from jax.random import KeyArray
 import jax.numpy as jnp
 from jaxtyping import Array, Float
@@ -36,7 +36,7 @@ class White(StationaryKernel):
         self._spectral_density = None
 
     def __call__(
-        self, params: Dict, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
+        self, params: Parameters, x: Float[Array, "1 D"], y: Float[Array, "1 D"]
     ) -> Float[Array, "1"]:
         """Evaluate the kernel on a pair of inputs :math:`(x, y)` with variance :math:`\\sigma`
 
@@ -44,7 +44,7 @@ class White(StationaryKernel):
             k(x, y) = \\sigma^2 \\delta(x-y)
 
         Args:
-            params (Dict): Parameter set for which the kernel should be evaluated on.
+            params (Parameters): Parameter set for which the kernel should be evaluated on.
             x (Float[Array, "1 D"]): The left hand argument of the kernel function's call.
             y (Float[Array, "1 D"]): The right hand argument of the kernel function's call.
 
@@ -61,7 +61,7 @@ class White(StationaryKernel):
             key (Float[Array, "1 D"]): The key to initialise the parameters with.
 
         Returns:
-            Dict: The initialised parameters.
+            Parameters: The initialised parameters.
         """
         params = {
             "variance": jnp.array([1.0]),


### PR DESCRIPTION
This PR cleans up the typing, cleans up the Graph Kernel object and exposes the `compute_class`.

Resolves Issues #53 and #50 